### PR TITLE
Show how to configure DynamoDB client to connect

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,13 @@ dynaliteServer.listen(4567, function(err) {
 })
 ```
 
+Then force your AWS DynamoDB client to connect to Dynalite by specifying `endpoint` in DynamoDB constructor params, eg, in NodeJS: 
+
+```js 
+var db = new AWS.DynamoDB({'endpoint': 'http://:::4567'});
+```
+
+
 Installation
 ------------
 


### PR DESCRIPTION
I had to struggle a little bit to understand how to connect to Dynalite, and had to read AWS SDK / DynamoDB documentation for a while to learn about the `endpoint` params property. 
As I don't think this is a obvious thing I have changed README.md to include this.
